### PR TITLE
Fixed outputFormat variable key name in JSON snippet in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Add `puyt/zazu-utime` inside of `plugins` block of your  `~/.zazurc.json` file.
         "name": "puyt/zazu-utime",
         "variables": {
             "timestampUnit": "milliseconds",
-            "timestampUnit": "{yyyy}/{MM}/{dd} {HH}:{mm}:{s}"
+            "outputFormat": "{yyyy}/{MM}/{dd} {HH}:{mm}:{s}"
         }
     }
   ]


### PR DESCRIPTION
I ran into an issue installing zazu-utime because the JSON snippet [1] had a typo. As you can see, the output format line has the key of "timestampUnit" when it should be "outputFormat." Copying and pasting this JSON into my config without noticing the error caused the "milliseconds" value to be overwritten, resulting in strange behavior.

[1]
``` json
{
  "plugins": [
    {
        "name": "puyt/zazu-utime",
        "variables": {
            "timestampUnit": "milliseconds",
            "timestampUnit": "{yyyy}/{MM}/{dd} {HH}:{mm}:{s}"
        }
    }
  ]
}
```